### PR TITLE
Expanded view rendering fix

### DIFF
--- a/src/components/cards/DashboardCard.js
+++ b/src/components/cards/DashboardCard.js
@@ -26,13 +26,13 @@ export default function DashboardCard({ personObj, onGiftUpdate, loading = false
       // Set timeout to make visible
       const timer = setTimeout(() => {
         setIsVisible(true);
-      }, 100);
+      }, 50);
 
       // Clean up timer
       return () => clearTimeout(timer);
-    } 
-      setIsVisible(false);
-    
+    }
+    setIsVisible(false);
+
     return () => {};
   }, [expandedView]);
 

--- a/src/components/cards/DashboardCard.js
+++ b/src/components/cards/DashboardCard.js
@@ -16,6 +16,25 @@ export default function DashboardCard({ personObj, onGiftUpdate, loading = false
   const [expandedView, setExpandedView] = useState(false);
   const { searchQuery } = useSearch();
   const { hideCompleted } = useHideCompleted();
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    if (expandedView) {
+      // Reset to hidden first
+      setIsVisible(false);
+
+      // Set timeout to make visible
+      const timer = setTimeout(() => {
+        setIsVisible(true);
+      }, 100);
+
+      // Clean up timer
+      return () => clearTimeout(timer);
+    } 
+      setIsVisible(false);
+    
+    return () => {};
+  }, [expandedView]);
 
   // Fetch all gifts once when personId changes
   useEffect(() => {
@@ -67,7 +86,7 @@ export default function DashboardCard({ personObj, onGiftUpdate, loading = false
 
   let cardHeight = 300;
   if (displayGifts.length > 2 && expandedView) {
-    cardHeight += (displayGifts.length - 2) * 55;
+    cardHeight += (displayGifts.length - 2) * 58;
   }
 
   // Sort gifts by date
@@ -108,17 +127,30 @@ export default function DashboardCard({ personObj, onGiftUpdate, loading = false
           </div>
         </div>
         <div className="flex flex-col justify-center items-center gap-2">
-          {expandedView
-            ? sortedGifts.map((gift) => (
-                <div key={gift.giftId} className="transition-all duration-300 ease-in-out">
-                  <GiftMiniCard giftObj={gift} onGiftUpdate={handleGiftUpdate} />
-                </div>
-              ))
-            : sortedGifts.slice(0, 2).map((gift) => (
+          {expandedView ? (
+            <>
+              {/* First two cards always visible */}
+              {sortedGifts.slice(0, 2).map((gift) => (
                 <div key={gift.giftId} className="transition-all duration-300 ease-in-out">
                   <GiftMiniCard giftObj={gift} onGiftUpdate={handleGiftUpdate} />
                 </div>
               ))}
+
+              {/* Additional cards with opacity transition */}
+              {sortedGifts.slice(2).map((gift) => (
+                <div key={gift.giftId} className={`transition-all duration-300 ease-in-out ${isVisible ? 'opacity-100' : 'opacity-0'}`}>
+                  <GiftMiniCard giftObj={gift} onGiftUpdate={handleGiftUpdate} />
+                </div>
+              ))}
+            </>
+          ) : (
+            // Non-expanded view: show only first two cards
+            sortedGifts.slice(0, 2).map((gift) => (
+              <div key={gift.giftId} className="transition-all duration-300 ease-in-out">
+                <GiftMiniCard giftObj={gift} onGiftUpdate={handleGiftUpdate} />
+              </div>
+            ))
+          )}
           {displayGifts.length > 2 && (
             <div className="w-full flex flex-col">
               <button type="button" className="justify-end text-white text-sm" onClick={() => setExpandedView(!expandedView)}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
<!--- Describe your changes in detail -->

- Edited rendering of giftminicards inside dashboard cards by adding a isVisible state with a setTimeout of 50 ms that changes the opacity of each gift minicard after the first 2 (any that we would see in the expanded view)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Can This Be Tested?
<!--- Please describe in detail how teammates can test your changes. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
