### PR TITLE
deleting person converts gifts to ideas

### DIFF
--- a/src/api/giftData.js
+++ b/src/api/giftData.js
@@ -64,6 +64,23 @@ const deleteGift = (giftId) =>
       .catch(reject);
   });
 
+// DELETE MULTIPLE GIFTS
+const deleteGifts = (gifts) =>
+  new Promise((resolve, reject) => {
+    Promise.all(
+      gifts.map((gift) =>
+        fetch(`${endpoint}/gifts/${gift.giftId}.json`, {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }),
+      ),
+    )
+      .then((responses) => resolve(responses))
+      .catch(reject);
+  });
+
 // GET SINGLE GIFT
 const getSingleGift = (giftId) =>
   new Promise((resolve, reject) => {
@@ -118,4 +135,4 @@ const getCompletedGifts = () =>
       .catch(reject);
   });
 
-export { createGift, updateGift, getGifts, deleteGift, getSingleGift, getGiftsByPersonId, getCompletedGifts };
+export { createGift, updateGift, getGifts, deleteGift, getSingleGift, getGiftsByPersonId, getCompletedGifts, deleteGifts };

--- a/src/api/personData.js
+++ b/src/api/personData.js
@@ -49,7 +49,7 @@ const getSinglePerson = (PersonId) =>
       .catch(reject);
   });
 
-// CREATE TOUR
+// CREATE PERSON
 const createPerson = (payload) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/people.json`, {
@@ -78,19 +78,5 @@ const updatePerson = (payload) =>
       .then((data) => resolve(data))
       .catch(reject);
   });
-
-// GET A SINGLE LOCATIONS TOURS
-// const getLocationTours = (locationId) =>
-//   new Promise((resolve, reject) => {
-//     fetch(`${endpoint}?location=${locationId}`, {
-//       method: 'GET',
-//       headers: {
-//         'Content-Type': 'application/json',
-//       },
-//     })
-//       .then((response) => response.json())
-//       .then((data) => resolve(Object.values(data)))
-//       .catch(reject);
-//   });
 
 export { createPerson, updatePerson, deletePerson, getPeople, getSinglePerson };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
<!--- Describe your changes in detail -->

- Deleting a person now converts all the gifts assigned to them into gift ideas.
- Created API call for deleting multiple gifts at once
- Added logic for deleting gifts and converting them into gift ideas

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#85 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Before, when deleting a person and going back to the gifts page, an error would appear.

## How Can This Be Tested?
<!--- Please describe in detail how teammates can test your changes. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
