### PR TITLE
added message for user when assigning gift idea when there are no people

### DIFF
--- a/src/components/cards/GiftIdeaCard.js
+++ b/src/components/cards/GiftIdeaCard.js
@@ -124,11 +124,15 @@ export default function GiftIdeaCard({ giftIdea, onGiftIdeaDelete, loading, onPe
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent>
-                {people.map((person) => (
-                  <DropdownMenuItem key={person.id} onSelect={() => handlePersonSelect(person, currentGiftIdea)}>
-                    {person.name}
-                  </DropdownMenuItem>
-                ))}
+                {people.length < 1 ? (
+                  <DropdownMenuItem disabled>You need to create a person before you can assign this gift.</DropdownMenuItem>
+                ) : (
+                  people.map((person) => (
+                    <DropdownMenuItem key={person.id} onSelect={() => handlePersonSelect(person, currentGiftIdea)}>
+                      {person.name}
+                    </DropdownMenuItem>
+                  ))
+                )}
               </DropdownMenuContent>
             </DropdownMenu>
           )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
<!--- Describe your changes in detail -->

- Added a message for the user if they try to assign a gift idea, that states: You need to create a person before you can assign this gift.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Can This Be Tested?
<!--- Please describe in detail how teammates can test your changes. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
